### PR TITLE
Fixed issue where we read in bcs BEFORE unifying the grid

### DIFF
--- a/src/peregrinepy/bootstrapCase.py
+++ b/src/peregrinepy/bootstrapCase.py
@@ -108,9 +108,9 @@ def bootstrapCase(config):
     mb.initSolverArrays(config)
 
     ################################################################
-    # Read in boundary conditions
+    # Read in periodic boundary condition info
     ################################################################
-    pg.readers.readBcs(mb, config["io"]["inputDir"])
+    pg.readers.readBcs(mb, config["io"]["inputDir"], justPeriodic=True)
 
     ################################################################
     # Unify the grid via halo construction, compute metrics
@@ -119,6 +119,13 @@ def bootstrapCase(config):
     mb.computeMetrics(config["RHS"]["diffOrder"])
     if rank == 0:
         print("Unified grid.")
+
+    ################################################################
+    # Read in boundary conditions
+    ################################################################
+    pg.readers.readBcs(mb, config["io"]["inputDir"], justPeriodic=False)
+    if rank == 0:
+        print("Set boundary conditions.")
 
     ################################################################
     # Register parallel writer

--- a/src/peregrinepy/readers/readBcs.py
+++ b/src/peregrinepy/readers/readBcs.py
@@ -5,18 +5,24 @@ import yaml
 from .. import bcs
 
 
-def readBcs(mb, pathToFile):
+def readBcs(mb, pathToFile, justPeriodic=False):
     """
-    This function parses a RAPTOR connectivity file given by
-    file_path and adds the connectivity information to the
-    supplied peregrinepy.multiBlock object
+    This function parses a PEREGRINE bcFam.yaml file given by
+    pathToFile and adds the relevant conditions to the boundary
+    conditions of the block faces.
 
     Parameters
     ----------
-    mb_data : peregrinepy.multiBlock.dataset (or a descendant)
+    mb : peregrinepy.multiBlock.topology (or a descendant)
 
-    file_path : str
-        Path to the conn.inp file to be read in
+    pathToFile : str
+        Path to the bcFam.yaml file to be read in
+
+    justPeriodic : bool
+        For runnning cases, we need periodic boundary info
+        BEFORE we unify the grid, but we need grid metrics
+        for some of the boundary condition types. So we want
+        to be able to read in just periodic info sometimes.
 
     Returns
     -------
@@ -79,6 +85,8 @@ def readBcs(mb, pathToFile):
             if bcType.startswith("periodic"):
                 face.periodicSpan = bcsIn[bcFam]["bcVals"]["periodicSpan"]
                 face.periodicAxis = bcsIn[bcFam]["bcVals"]["periodicAxis"]
+                continue
+            if justPeriodic:
                 continue
 
             # If we are a solver face, we need to create the kokkos arrays

--- a/tests/boundaryConditions/bcBlock.py
+++ b/tests/boundaryConditions/bcBlock.py
@@ -87,7 +87,7 @@ def create(bc, adv, spdata):
         # Conservative like bcs
         face.array["QBcVals"] = np.zeros((blk.array["Q"][face.s1_].shape))
         inputBcValues["mDotPerUnitArea"] = mDotPerAbc
-        # Just so we can check we set the target mdot to the zeroth (unuzed)
+        # Just so we can check we set the target mdot to the zeroth (unused)
         # index of the QBcVals
         face.array["QBcVals"][:, :, 0] = mDotPerAbc
 


### PR DESCRIPTION
but some bc information needs grid metrics to work correctly.
So now we can toggle between reading in just periodic info
and all the other info as well.